### PR TITLE
Hide main page's 'News and views' and 'Add to your feed' sections

### DIFF
--- a/linkedin-feed-blocker.css
+++ b/linkedin-feed-blocker.css
@@ -1,6 +1,8 @@
 .feed-new-update-pill__new-update-button,
 .feed-right-rail,
 .feed-shared-update-v2,
-.nav-item__badge--doughnut {
+.nav-item__badge--doughnut,
+.feed-shared-news-module,
+.feed-follows-module {
 	display: none !important;
 }


### PR DESCRIPTION
Fixes #1 

Hides the 'Today's news and views' and 'Add to your feed' sections:
<img width="929" alt="example" src="https://user-images.githubusercontent.com/1288541/83976358-4db98080-a8ae-11ea-9024-c86863adc296.png">


I tried to keep the commit message in the same format.